### PR TITLE
Modify queries to align with the scheme required by the gateway

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/skilllevel_service/controller/SkillLevelController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/skilllevel_service/controller/SkillLevelController.java
@@ -11,6 +11,7 @@ import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -21,19 +22,17 @@ public class SkillLevelController {
     private final SkillLevelService skilllevelService;
 
     @QueryMapping
-    public SkillLevels userSkillLevels(@Argument UUID chapterId, @ContextValue LoggedInUser currentUser) {
-        return skilllevelService.getSkillLevels(chapterId, currentUser.getId());
+    public List<SkillLevels> userSkillLevelsByChapterIds(@Argument List<UUID> chapterIds, @ContextValue LoggedInUser currentUser) {
+        return skilllevelService.getSkillLevelsForChapters(chapterIds, currentUser.getId());
     }
 
     @QueryMapping
-    public SkillLevels skillLevelsForUser(@Argument UUID chapterId, @Argument UUID userId) {
-        return skilllevelService.getSkillLevels(chapterId, userId);
+    public List<SkillLevels> skillLevelsForUserByChapterIds(@Argument List<UUID> chapterIds, @Argument UUID userId) {
+        return skilllevelService.getSkillLevelsForChapters(chapterIds, userId);
     }
 
     @MutationMapping
     public SkillLevels recalculateLevels(@Argument UUID chapterId, @Argument UUID userId) {
         return skilllevelService.recalculateLevels(chapterId, userId);
     }
-
-
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,14 +1,12 @@
 type Query {
   """
-  Get the skill levels of the current user for all skill types (Bloom taxonomy) in a chapter of a course.
-  If chapterId is null, then the skill levels for the course are returned.
+  Get the skill levels of the current user for all skill types for a list of chapter ids.
   """
-  userSkillLevels(chapterId: UUID): SkillLevels!
+  userSkillLevelsByChapterIds(chapterIds: [UUID!]!): [SkillLevels!]!
   """
-  Get the skill levels of the specified user for all skill types (Bloom taxonomy) in a chapter of a course.
-  If chapterId is null, then the skill levels for the course are returned.
+  Get the skill levels of the specified user for all skill types for a list of chapter ids.
   """
-  skillLevelsForUser(chapterId: UUID, userId: UUID!): SkillLevels!
+  skillLevelsForUserByChapterIds(chapterIds: [UUID!]!, userId: UUID!): [SkillLevels!]!
 }
 
 type Mutation {

--- a/src/test/java/de/unistuttgart/iste/gits/skilllevel_service/SkillLevelServiceTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/skilllevel_service/SkillLevelServiceTest.java
@@ -42,7 +42,7 @@ class SkillLevelServiceTest {
         UUID chapterId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
 
-        SkillLevels skillLevels = skillLevelService.getSkillLevels(chapterId, userId);
+        SkillLevels skillLevels = skillLevelService.getSkillLevelsForChapters(List.of(chapterId), userId).get(0);
 
         assertThat(skillLevels.getAnalyze().getValue()).isZero();
         assertThat(skillLevels.getApply().getValue()).isZero();


### PR DESCRIPTION
## Description of changes
For better integration in the gateway (performance improvements) the query schema had to be modified to allow fetching of skill level data for multiple chapters in a single query.

  
## How has this been tested?
Please describe the test strategy you followed.

- [x] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test

    
## Checklist before requesting a review
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
