### PR TITLE
Fix ContentServiceClient getChapterIdOfContent

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/skilllevel_service/service/ContentServiceClient.java
+++ b/src/main/java/de/unistuttgart/iste/gits/skilllevel_service/service/ContentServiceClient.java
@@ -53,14 +53,16 @@ public class ContentServiceClient {
             String query = """
                     query($contentId: UUID!) {
                         contentsByIds(ids: [$contentId]) {
-                            chapterId
+                            metadata {
+                                chapterId
+                            }
                         }
                     }
                     """;
 
             return client.document(query)
                     .variable("contentId", contentId)
-                    .retrieve("contentsByIds[0].chapterId").toEntity(UUID.class)
+                    .retrieve("contentsByIds[0].metadata.chapterId").toEntity(UUID.class)
                     .retry(RETRY_COUNT)
                     .block();
 


### PR DESCRIPTION
## Description of changes
Fixes the ContentServiceClient getChapterIdOfContent method, it used a wrong query structure.

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test
    
## Checklist before requesting a review
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
